### PR TITLE
Ajustar nomes dos arquivos dos certificados

### DIFF
--- a/app/DAO/EnsinoPesquisaExtensao/CertificadoDAO.php
+++ b/app/DAO/EnsinoPesquisaExtensao/CertificadoDAO.php
@@ -130,6 +130,7 @@ class CertificadoDAO
         return [
             'curso' => $curso,
             'modulos' => $modulos,
+            'oferta' => $ofertaCursoTurma,
         ];
     }
 
@@ -147,12 +148,16 @@ class CertificadoDAO
         $situacaoaluno = 'Aprovado'
     ) {
 
+        $basdocumentTypeCPF = 2;
+
         // sem inscricaoid
         if (is_null($inscricaoid)) {
 
             $select = DB::select(
                 "SELECT DISTINCT
                     ITG.inscricaoid,
+                    unmaskcpf(DOC.content) as cpf,
+                    PERSON.miolousername,
                     PERSON.name as nome,
                     acp_obtersituacaopedagogicadainscricao(ITG.inscricaoid) as situacaoaluno
                 FROM acpinscricaoturmagrupo ITG
@@ -160,6 +165,8 @@ class CertificadoDAO
                     ON (ITG.inscricaoturmagrupoid = MAT.inscricaoturmagrupoid)
                 LEFT JOIN ONLY basperson PERSON
                     ON (MAT.personid = PERSON.personid)
+                LEFT JOIN basdocument DOC
+                    ON (PERSON.personid = DOC.personid) and DOC.documenttypeid = $basdocumentTypeCPF
                 WHERE ITG.ofertaturmaid = :ofertaturmaid
                 AND acp_obtersituacaopedagogicadainscricao(ITG.inscricaoid) = :situacaoaluno
                 ORDER BY PERSON.name",
@@ -175,14 +182,18 @@ class CertificadoDAO
         // com inscricaoid
         $select = DB::select(
             "SELECT DISTINCT
-                ITG.inscricaoid,
-                PERSON.name as nome,
-                acp_obtersituacaopedagogicadainscricao(ITG.inscricaoid) as situacaoaluno
+                    ITG.inscricaoid,
+                    unmaskcpf(DOC.content) as cpf,
+                    PERSON.miolousername,
+                    PERSON.name as nome,
+                    acp_obtersituacaopedagogicadainscricao(ITG.inscricaoid) as situacaoaluno
             FROM acpinscricaoturmagrupo ITG
             LEFT JOIN acpmatricula MAT
                 ON (ITG.inscricaoturmagrupoid = MAT.inscricaoturmagrupoid)
             LEFT JOIN ONLY basperson PERSON
                 ON (MAT.personid = PERSON.personid)
+            LEFT JOIN basdocument DOC
+                ON (PERSON.personid = DOC.personid) and DOC.documenttypeid = $basdocumentTypeCPF
             WHERE ITG.ofertaturmaid = :ofertaturmaid
             AND ITG.inscricaoid = :inscricaoid
             AND acp_obtersituacaopedagogicadainscricao(ITG.inscricaoid) = :situacaoaluno

--- a/app/Http/Controllers/EnsinoPesquisaExtensao/CertificateController.php
+++ b/app/Http/Controllers/EnsinoPesquisaExtensao/CertificateController.php
@@ -19,14 +19,14 @@ class CertificateController extends Controller
     {
         $info = $this->generateCertificate($turmaId, $incricaoid);
 
-        $this->certificate_service->generatePDF($info);
+        return $this->certificate_service->generatePDF($info);
     }
 
     public function generateCertificateByClass($turmaId)
     {
         $info = $this->generateCertificate($turmaId);
 
-        $this->certificate_service->generatePDF($info);
+        return $this->certificate_service->generatePDF($info);
     }
 
     private function generateCertificate($turmaId, $incricaoid = null)
@@ -40,6 +40,7 @@ class CertificateController extends Controller
         return [
             'curso' => $cursoMatrizCurricular['curso'],
             'modulos' => $cursoMatrizCurricular['modulos'],
+            'oferta' => $cursoMatrizCurricular['oferta'],
             'estudantes' => $estudantes
         ];
     }


### PR DESCRIPTION
- Encurtar nomes dos arquivos
- Inserir nome da turma no arquivo zip
- Inserir CPF do aluno no arquivo PDF do certificado

Obs.: O nome da turma e o CPF foi inserido a pedido dos gestores para facilitar na busca, pois os arquivos serão armazenados em uma pasta para backup

https://github.com/EscolaDeSaudePublica/FeliciLab/issues/356